### PR TITLE
port from Moose to Moo

### DIFF
--- a/lib/App/BatParser.pm
+++ b/lib/App/BatParser.pm
@@ -3,7 +3,7 @@ package App::BatParser;
 use utf8;
 
 use Regexp::Grammars;
-use Moose;
+use Moo;
 use namespace::autoclean;
 
 # VERSION


### PR DESCRIPTION
Okay, so that was easy.

On my laptop, this reduces the time taken to run the test suite from 1.05 wallclock seconds to 0.53 wallclock seconds. Should save quite a bit of memory too.