### PR TITLE
Support to goto :label (with colon in the begining)

### DIFF
--- a/lib/App/BatParser.pm
+++ b/lib/App/BatParser.pm
@@ -76,7 +76,7 @@ has 'grammar' => (
 
            <rule: Call> call <Token>
 
-           <rule: Goto> Goto <Identifier=LabelIdentifier>
+           <rule: Goto> Goto :?<Identifier=LabelIdentifier>
 
            <rule: Set> set <Variable=Token>=<Value=Token>
 

--- a/t/07-goto_label_stating_with_colon.cmd
+++ b/t/07-goto_label_stating_with_colon.cmd
@@ -1,0 +1,12 @@
+@echo off
+
+goto :label
+
+echo Never get executed
+
+:label
+
+echo Executing!
+
+
+

--- a/t/07-goto_label_stating_with_colon.t
+++ b/t/07-goto_label_stating_with_colon.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 1;
+use English qw( -no_match_vars );
+use App::BatParser;
+use Path::Tiny;
+
+{
+    my $ast_expected = {
+
+          'File' => {
+                      'Lines' => [
+                                   {
+                                     'Statement' => {
+                                                      'Command' => {
+                                                                     'SpecialCommand' => {
+                                                                                           'Echo' => {
+                                                                                                       'EchoModifier' => 'off'
+                                                                                                     }
+                                                                                         }
+                                                                   }
+                                                    }
+                                   },
+                                   {
+                                     'Statement' => {
+                                                      'Command' => {
+                                                                     'SpecialCommand' => {
+                                                                                           'Goto' => {
+                                                                                                       'Identifier' => 'label'
+                                                                                                     }
+                                                                                         }
+                                                                   }
+                                                    }
+                                   },
+                                   {
+                                     'Statement' => {
+                                                      'Command' => {
+                                                                     'SpecialCommand' => {
+                                                                                           'Echo' => {
+                                                                                                       'Message' => 'Never get executed'
+                                                                                                     }
+                                                                                         }
+                                                                   }
+                                                    }
+                                   },
+                                   {
+                                     'Label' => {
+                                                  'Identifier' => 'label'
+                                                }
+                                   },
+                                   {
+                                     'Statement' => {
+                                                      'Command' => {
+                                                                     'SpecialCommand' => {
+                                                                                           'Echo' => {
+                                                                                                       'Message' => 'Executing!'
+                                                                                                     }
+                                                                                         }
+                                                                   }
+                                                    }
+                                   },
+                                   ,
+                                   {
+                                     'Statement' => {
+                                                      'Command' => ''
+                                                    }
+                                   },
+                                 ]
+                    }
+            };
+    my $cmd_file = $PROGRAM_NAME;
+    $cmd_file =~ s/\.t/\.cmd/;
+    my $cmd_contents = path($cmd_file)->slurp;
+    my $parser = App::BatParser->new;
+    my $ast = $parser->parse($cmd_contents);
+
+    is_deeply($ast, $ast_expected, 'Simple cmd');
+}
+


### PR DESCRIPTION
Hello again! 

Apparently, we miss something else in the [documentation](https://ss64.com/nt/goto.html)

> Although undocumented, GOTO :MySubroutine generally has the same effect as GOTO MySubroutine
or GOTO:MySubroutine (a colon in place of the space)

So here, now the parser also parse this particular case.

I hope this is going to be the last _pull request_ in this particular subject ^^